### PR TITLE
Fixes, adjustments and deployment of conf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ I might add support for some other OS, if and when I'm bored.
 * allow to enable/disable config files
 * allow to enable/disable modules
 
+#### Known limitations
+
+##### Ports
+
+* if there are no virtual hosts, httpd should listen at port 80 and 443 as is
+  by default in Debian.
+* ports are generated **ONLY** from managed(defined) virtual hosts. There is
+  currently no way around this.
+
+##### Virtual Hosts
+
+Virtual host filename is assembled from priority, protocol and servername. If
+any of these change, new filename will be created and the old one will be left
+behind since unmanaged stuff is left alone. This is kind of suboptimal.
+
+One way around this is either duplicate the whole virtual host configuration or
+create a minimal stub with identical combination of port, servername and
+ssl/no-ssl and `state: absent`. Then the former virtual host should get
+disabled and new one deployed.
+
 ## Requirements
 
 None.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,16 @@ There are no extra dependencies as far as Ansible goes.
     apache_mods:
       - name: rewrite
         state: present
+      - name: ssl
+        conf_content: |
+          SSLProtocol all -SSLv2 -SSLv3 -TLSv1
 
     apache_confs:
       - name: serve-cgi-bin
         state: absent
+      - name: my_config
+        conf_content: |
+          TraceEnable On
   roles:
      - role: zstyblik.apache
 ```

--- a/action_plugins/apache_ports_generator.py
+++ b/action_plugins/apache_ports_generator.py
@@ -49,7 +49,10 @@ class ActionModule(ActionBase):
 
         vhosts = self._task.args.get("vhosts", [])
         if not vhosts:
-            vhosts = [{"listen_ip": "", "port": 80, "ssl": False}]
+            vhosts = [
+                {"listen_ip": "", "port": 80, "ssl": {}},
+                {"listen_ip": "", "port": 443, "ssl": {}},
+            ]
 
         # Ref. https://httpd.apache.org/docs/2.4/bind.html
         # Structure:
@@ -84,10 +87,10 @@ class ActionModule(ActionBase):
             if port not in bindings:
                 bindings[port] = {}
 
-            ssl = vhost.get("ssl", False)
+            ssl = vhost.get("ssl", {})
             # According to documentation, https is default proto for port 443.
             # Therefore there is no need to specify it.
-            if ssl is True and port != 443:
+            if ssl and port != 443:
                 ssl = "https"
             else:
                 ssl = ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,12 @@ apache_vhosts:
 # Only used on Debian/Ubuntu.
 # Example:
 # apache_mods:
-#   - name: rewrite
+#   - name: ssl
 #     state: present
+#     # Create or overwrite .conf file with the following content.
+#     # This can be used to override/neuter default mod configuration.
+#     conf_content: |
+#       SSLProtocol all -SSLv2 -SSLv3 -TLSv1
 apache_mods: []
 
 # Only used on Debian/Ubuntu.
@@ -22,6 +26,11 @@ apache_mods: []
 # apache_confs:
 #   - name: trace
 #     state: absent
+#   - name: my_config
+#     state: present
+#     # Create or overwrite .conf file with the following content.
+#     conf_content: |
+#       TraceEnable On
 apache_confs: []
 
 # httpd.conf

--- a/filter_plugins/core.py
+++ b/filter_plugins/core.py
@@ -57,14 +57,14 @@ def parse_a2query(stdout):
 def to_vhost_filename(vhost):
     """Turn apache_vhost item(dict) into a filename."""
     try:
-        priority = int(vhost.get("priority", 25))
+        priority = int(vhost.get("priority", 200))
         if "ssl" in vhost and vhost["ssl"]:
             proto = "https"
         else:
             proto = "http"
 
         servername = vhost["servername"]
-        result = "{:d}-{:s}_{:s}".format(priority, proto, servername)
+        result = "{:03d}-{:s}_{:s}".format(priority, proto, servername)
     except Exception as exception:
         raise AnsibleFilterError(
             "to_vhost_filename - {:s}".format(to_native(exception)),

--- a/specs/apache_conf_argument_specs.yml
+++ b/specs/apache_conf_argument_specs.yml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+argument_specs:
+  apache_conf_item:
+    short_description: Specification of Apache httpd conf/module item.
+    description: Specification of Apache httpd conf/module item.
+    options:
+      name:
+        description: Name of Apache's httpd configuration file(fragment).
+        required: true
+        type: str
+      state:
+        description: State of configuration file - present, absent etc.
+        required: false
+        type: str
+        choices: ['present', 'absent', 'purged']
+      conf_content:
+        description: Content of configuration file itself.
+        required: false
+        type: str

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -274,7 +274,9 @@
       - "{{ apache_default_vhost_filename }}"
   register: _apache_cmd_a2dissite_default
   changed_when: "'To activate the new configuration' in _apache_cmd_a2dissite_default.stdout_lines"
-  failed_when: _apache_cmd_a2dissite_default.rc != 0
+  failed_when:
+    - _apache_cmd_a2dissite_default.rc != 0
+    - "_apache_cmd_a2dissite_default.stderr is not search('ERROR: Site .+ does not exist!')"
   when:
     - apache_remove_default_vhost is true
     - apache_default_vhost_filename is defined

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -104,81 +104,22 @@
   ansible.builtin.set_fact:
     _apache_a2q_confs: "{{ _apache_cmd_a2q_confs.stdout_lines | parse_a2query }}"
 
-# NOTE(zstyblik): run a2en* regardless
-# re-add check "is in a2q STDOUT", if necessary to save cycles.
-- name: Enable desired Apache confs.
-  ansible.builtin.command:
-    argv:
-      - /usr/sbin/a2enconf
-      - -q
-      - "{{ item.name }}"
-  register: _apache_cmd_a2enconf
-  changed_when: "'To activate the new configuration' in _apache_cmd_a2enconf.stdout_lines"
-  failed_when: _apache_cmd_a2enconf.rc != 0
+- name: Configure Apache configuration files(fragment).
+  ansible.builtin.include_tasks:
+    file: configure-conf-file.yml
   loop: "{{ apache_confs }}"
   loop_control:
-    label: "{{ item.name }}"
-  when:
-    - item.state | default('present') == 'present'
-  notify: restart apache
-  become: true
-
-- name: Disable desired Apache confs.
-  ansible.builtin.command:
-    argv:
-      - /usr/sbin/a2disconf
-      - -q
-      - "{{ item.name }}"
-  register: _apache_cmd_a2disconf
-  changed_when: "'To activate the new configuration' in _apache_cmd_a2disconf.stdout_lines"
-  failed_when: _apache_cmd_a2disconf.rc != 0
-  loop: "{{ apache_confs }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when:
-    - item.state | default('present') != 'present'
-    - item.name in _apache_a2q_confs
-  notify: restart apache
-  become: true
+    label: "{{ _apache_conf_item.name | default('unknown') }}"
+    loop_var: _apache_conf_item
 
 # Apache mods
-# NOTE(zstyblik): run a2en* regardless
-# re-add check "is in a2q STDOUT", if necessary to save cycles.
-- name: Enable desired Apache mods.
-  ansible.builtin.command:
-    argv:
-      - /usr/sbin/a2enmod
-      - -q
-      - "{{ item.name }}"
-  register: _apache_cmd_a2enmod
-  changed_when: "'To activate the new configuration' in _apache_cmd_a2enmod.stdout_lines"
-  failed_when: _apache_cmd_a2enmod.rc != 0
+- name: Configure Apache modules.
+  ansible.builtin.include_tasks:
+    file: configure-mod-file.yml
   loop: "{{ apache_mods }}"
   loop_control:
-    label: "{{ item.name }}"
-  when:
-    - item.state | default('present') == 'present'
-  notify: restart apache
-  become: true
-
-- name: Disable desired Apache mods.
-  ansible.builtin.command:
-    argv:
-      - /usr/sbin/a2dismod
-      - -q
-      - "{{ item.name }}"
-  register: _apache_cmd_a2dismod
-  changed_when: "'To activate the new configuration' in _apache_cmd_a2dismod.stdout_lines"
-  failed_when: _apache_cmd_a2dismod.rc != 0
-  loop: "{{ apache_mods }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when:
-    - item.state | default('present') != 'present'
-    - item.name in _apache_a2q_mods
-    - item.name != _apache_mpm_module
-  notify: restart apache
-  become: true
+    label: "{{ _apache_mod_item.name | default('unknown') }}"
+    loop_var: _apache_mod_item
 
 # Apache vhosts
 - name: Get list of enabled Apache sites.

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -190,7 +190,7 @@
   changed_when: false
   failed_when:
     - _apache_cmd_a2q_sites.rc != 0
-    - _apache_cmd_a2q_sites.rc != 32
+    - "'No site matches' not in _apache_cmd_a2q_sites.stderr"
   become: true
 
 - name: Parse enabled sites from a2query's output.

--- a/tasks/configure-conf-file.yml
+++ b/tasks/configure-conf-file.yml
@@ -1,0 +1,56 @@
+---
+- name: Check conf configuration against spec file
+  ansible.builtin.validate_argument_spec:
+    argument_spec: |
+      {{
+        (
+          lookup(
+            'ansible.builtin.file',
+            'specs/apache_conf_argument_specs.yml'
+          ) | from_yaml
+        )['argument_specs']['apache_conf_item']['options']
+      }}
+    provided_arguments: "{{ _apache_conf_item }}"
+
+- name: Create Apache config file.
+  ansible.builtin.copy:
+    content: "{{ _apache_conf_item.conf_content }}"
+    dest: "{{ apache_httpd_conf_load_dir }}/{{ _apache_conf_item.name }}.conf"
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - _apache_conf_item.state | default('present') == 'present'
+    - _apache_conf_item.conf_content is defined
+  become: true
+
+# NOTE(zstyblik): run a2en* regardless
+# re-add check "is in a2q STDOUT", if necessary to save cycles.
+- name: Enable Apache config file.
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/a2enconf
+      - -q
+      - "{{ _apache_conf_item.name }}"
+  register: _apache_cmd_a2enconf
+  changed_when: "'To activate the new configuration' in _apache_cmd_a2enconf.stdout_lines"
+  failed_when: _apache_cmd_a2enconf.rc != 0
+  when:
+    - _apache_conf_item.state | default('present') == 'present'
+  notify: restart apache
+  become: true
+
+- name: Disable Apache config file.
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/a2disconf
+      - -q
+      - "{{ _apache_conf_item.name }}"
+  register: _apache_cmd_a2disconf
+  changed_when: "'To activate the new configuration' in _apache_cmd_a2disconf.stdout_lines"
+  failed_when: _apache_cmd_a2disconf.rc != 0
+  when:
+    - _apache_conf_item.state | default('present') != 'present'
+    - _apache_conf_item.name in _apache_a2q_confs
+  notify: restart apache
+  become: true

--- a/tasks/configure-mod-file.yml
+++ b/tasks/configure-mod-file.yml
@@ -1,0 +1,57 @@
+---
+- name: Check mod configuration against spec file
+  ansible.builtin.validate_argument_spec:
+    argument_spec: |
+      {{
+        (
+          lookup(
+            'ansible.builtin.file',
+            'specs/apache_conf_argument_specs.yml'
+          ) | from_yaml
+        )['argument_specs']['apache_conf_item']['options']
+      }}
+    provided_arguments: "{{ _apache_mod_item }}"
+
+- name: Create config file for Apache module.
+  ansible.builtin.copy:
+    content: "{{ _apache_mod_item.conf_content }}"
+    dest: "{{ apache_httpd_mod_load_dir }}/{{ _apache_mod_item.name }}.conf"
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - _apache_mod_item.state | default('present') == 'present'
+    - _apache_mod_item.conf_content is defined
+  become: true
+
+# NOTE(zstyblik): run a2en* regardless
+# re-add check "is in a2q STDOUT", if necessary to save cycles.
+- name: Enable Apache module.
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/a2enmod
+      - -q
+      - "{{ _apache_mod_item.name }}"
+  register: _apache_cmd_a2enmod
+  changed_when: "'To activate the new configuration' in _apache_cmd_a2enmod.stdout_lines"
+  failed_when: _apache_cmd_a2enmod.rc != 0
+  when:
+    - _apache_mod_item.state | default('present') == 'present'
+  notify: restart apache
+  become: true
+
+- name: Disable Apache module.
+  ansible.builtin.command:
+    argv:
+      - /usr/sbin/a2dismod
+      - -q
+      - "{{ _apache_mod_item.name }}"
+  register: _apache_cmd_a2dismod
+  changed_when: "'To activate the new configuration' in _apache_cmd_a2dismod.stdout_lines"
+  failed_when: _apache_cmd_a2dismod.rc != 0
+  when:
+    - _apache_mod_item.state | default('present') != 'present'
+    - _apache_mod_item.name in _apache_a2q_mods
+    - _apache_mod_item.name != _apache_mpm_module
+  notify: restart apache
+  become: true

--- a/templates/httpd.conf.j2
+++ b/templates/httpd.conf.j2
@@ -183,38 +183,46 @@ LDAPTrustedMode {{ apache_httpd_ldap_trusted_mode }}
 {% endif %}
 
 {% if apache_httpd_error_documents_path %}
-Alias /error/ "{{ apache_httpd_error_documents_path }}/"
+# The internationalized error documents require mod_alias, mod_include
+# and mod_negotiation.
+<IfModule mod_negotiation.c>
+  <IfModule mod_include.c>
+    <IfModule mod_alias.c>
 
-<Directory "{{ apache_httpd_error_documents_path }}">
-  AllowOverride None
-  Options IncludesNoExec
-  AddOutputFilter Includes html
-  AddHandler type-map var
-{% if apache_version.startswith('2.4') %}
-  Require all granted
-{% else %}
-  Order allow,deny
-  Allow from all
-{% endif %}
-  LanguagePriority en cs de es fr it nl sv pt-br ro
-  ForceLanguagePriority Prefer Fallback
-</Directory>
+      Alias /error/ "/usr/share/apache2/error/"
 
-ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
-ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
-ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
-ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
-ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
-ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
-ErrorDocument 410 /error/HTTP_GONE.html.var
-ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
-ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
-ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
-ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
-ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
-ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
-ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
-ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
-ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
-ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
+      <Directory "/usr/share/apache2/error">
+        Options IncludesNoExec
+        AddOutputFilter Includes html
+        AddHandler type-map var
+        {% if apache_version.startswith('2.4') %}
+        Require all granted
+        {% else %}
+        Order allow,deny
+        Allow from all
+        {% endif %}
+        LanguagePriority en cs de es fr it nl sv pt-br ro
+        ForceLanguagePriority Prefer Fallback
+      </Directory>
+
+      ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
+      ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
+      ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
+      ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
+      ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
+      ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
+      ErrorDocument 410 /error/HTTP_GONE.html.var
+      ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
+      ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
+      ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
+      ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
+      ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
+      ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
+      ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
+      ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
+      ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
+      ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
+    </IfModule>
+  </IfModule>
+</IfModule>
 {% endif %}

--- a/templates/vhost.conf.j2
+++ b/templates/vhost.conf.j2
@@ -101,7 +101,7 @@
 {% endfor %}
 {% endif %}
 {% if apache_vhost.extra_parameters is defined %}
-  {{ apache_vhost.extra_parameters }}
+  {{ apache_vhost.extra_parameters | indent(2) }}
 {% endif %}
 {% set error_log = apache_vhost.error_log | default('true') %}
 {% if apache_vhost.error_log_destination is defined and apache_vhost.error_log_destination != '' %}


### PR DESCRIPTION
* Handle case when there are no sites enabled and a2query RC=1
* Fix command evaluation when default virtual host is being disabled
* Fix configuration of error documents in httpd template
* Change formatting of priority and default from 25 to 200
* If there are no vhosts at all, listen at port 80 and 443
* Implement deployment of conf files and conf files for modules
* Describe some limitations in README.md